### PR TITLE
Remove old specs left over from daemons_directory

### DIFF
--- a/spec/lib/daemons/rails/configuration_spec.rb
+++ b/spec/lib/daemons/rails/configuration_spec.rb
@@ -10,7 +10,6 @@ describe Daemons::Rails::Configuration do
     describe "rails env" do
       its(:root) { should == Rails.root }
       its(:daemons_path) { should == Rails.root.join('lib', 'daemons') }
-      its(:daemons_path) { should == Pathname.new('lib').join('daemons') }
     end
 
     describe "no rails" do
@@ -26,7 +25,6 @@ describe Daemons::Rails::Configuration do
       end
       its(:root) { should == Rails_.root }
       its(:daemons_path) { should == Rails_.root.join('lib', 'daemons') }
-      its(:daemons_path) { should == Pathname.new('lib').join('daemons') }
     end
   end
 
@@ -42,7 +40,6 @@ describe Daemons::Rails::Configuration do
     end
 
     its(:daemons_path) { should == Rails.root.join('daemons') }
-    its(:daemons_path) { should == Pathname.new('daemons') }
 
     it "should override daemons directory" do
       Daemons::Rails::Monitoring.daemons_path.should == Rails.root.join('daemons')


### PR DESCRIPTION
Looks like these were left in from a mass search-replace operation. The
removed specs contradict the assertion that came above each of them.

There's still one spec failing, but I don't have the time to address it
right now. I believe it has to do with the custom daemon directory.
