### PR TITLE
ruby 3.2 compatibility

### DIFF
--- a/lib/daemons/rails/config.rb
+++ b/lib/daemons/rails/config.rb
@@ -10,7 +10,7 @@ module Daemons
       def initialize(app_name, root_path, daemons_dir = File.join('lib', 'daemons'))
         @options = {}
         config_path = File.join(root_path, "config", "#{app_name}-daemon.yml")
-        config_path = File.join(root_path, "config", "daemons.yml") unless File.exists?(config_path)
+        config_path = File.join(root_path, "config", "daemons.yml") unless File.exist?(config_path)
         options = YAML.load(ERB.new(IO.read(config_path)).result)
         options.each { |key, value| @options[key.to_sym] = value }
         @options[:dir_mode] = @options[:dir_mode].to_sym

--- a/lib/daemons/rails/configuration.rb
+++ b/lib/daemons/rails/configuration.rb
@@ -12,7 +12,7 @@ module Daemons
         else
           root = Pathname.new(FileUtils.pwd)
           root = root.parent unless root.directory?
-          root = root.parent until File.exists?(root.join('config.ru')) || root.root?
+          root = root.parent until File.exist?(root.join('config.ru')) || root.root?
           raise "Can't detect Rails application root" if root.root?
           root
         end

--- a/lib/generators/daemon_generator.rb
+++ b/lib/generators/daemon_generator.rb
@@ -8,7 +8,7 @@ class DaemonGenerator < Rails::Generators::NamedBase
   def generate_daemon
     daemons_dir = Daemons::Rails.configuration.daemons_directory
 
-    unless File.exists?(Rails.root.join(daemons_dir, 'daemons'))
+    unless File.exist?(Rails.root.join(daemons_dir, 'daemons'))
       copy_file "daemons", daemons_dir.join('daemons')
       chmod daemons_dir.join('daemons'), 0755
     end
@@ -19,7 +19,7 @@ class DaemonGenerator < Rails::Generators::NamedBase
     template "script_ctl", daemons_dir.join("#{file_name}_ctl")
     chmod daemons_dir.join("#{file_name}_ctl"), 0755
 
-    unless File.exists?(Rails.root.join("config", "daemons.yml"))
+    unless File.exist?(Rails.root.join("config", "daemons.yml"))
       copy_file "daemons.yml", "config/daemons.yml"
     end
   end

--- a/lib/generators/templates/script.rb
+++ b/lib/generators/templates/script.rb
@@ -4,7 +4,7 @@
 ENV["RAILS_ENV"] ||= "production"
 
 root = File.expand_path(File.dirname(__FILE__))
-root = File.dirname(root) until File.exists?(File.join(root, 'config'))
+root = File.dirname(root) until File.exist?(File.join(root, 'config'))
 Dir.chdir(root)
 
 require File.join(root, "config", "environment")


### PR DESCRIPTION
Ruby 3.2 deprecates File.exists? in favour for File.exist? (Which has always been valid).